### PR TITLE
Fix NameError name key is not defined

### DIFF
--- a/src/app/helpers/tools.py
+++ b/src/app/helpers/tools.py
@@ -134,7 +134,7 @@ def get_python_rsa_keys_signer(rerun=True) -> PythonRSASigner:
         if not os.path.isfile(path):
             if not os.path.isdir(path):
                 os.mkdir(path)
-            keygen(key)
+            keygen(privkey)
             return get_python_rsa_keys_signer(False)
 
 


### PR DESCRIPTION
Bug fix

bash run.sh

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/user/GitHub/ADBFileExplorer/./src/app/__main__.py", line 21, in <module>
    from core.main import Adb
  File "/home/user/GitHub/ADBFileExplorer/./src/app/core/main.py", line 9, in <module>
    from app.core.managers import PythonADBManager, ADBManager, WorkersManager
  File "/home/user/GitHub/ADBFileExplorer/src/app/core/managers.py", line 70, in <module>
    class PythonADBManager(ADBManager):
  File "/home/user/GitHub/ADBFileExplorer/src/app/core/managers.py", line 71, in PythonADBManager
    signer = get_python_rsa_keys_signer()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/GitHub/ADBFileExplorer/src/app/helpers/tools.py", line 137, in get_python_rsa_keys_signer
    keygen(key)
           ^^^
NameError: name 'key' is not defined